### PR TITLE
Added support for wrapping customization.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    
+
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>9</version>
     </parent>
-    
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.dgautier</groupId>
     <artifactId>boxable</artifactId>
@@ -61,6 +61,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <compilerArguments>
+                        <bootclasspath>${sun.boot.class.path}${path.separator}${java.home}/lib/jfxrt.jar</bootclasspath>
+                    </compilerArguments>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>external.atlassian.jgitflow</groupId>

--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -6,6 +6,7 @@ package be.quodlibet.boxable;
 
 import java.awt.Color;
 import java.io.IOException;
+import java.util.function.Function;
 
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.font.PDFont;
@@ -18,12 +19,12 @@ public class Cell<T extends PDPage> {
 
 	private PDFont font = PDType1Font.HELVETICA;
 	private PDFont fontBold = PDType1Font.HELVETICA_BOLD;
-	
+
 	private float fontSize = 8;
 	private Color fillColor;
 	private Color textColor = Color.BLACK;
 	private final Row<T> row;
-	
+	private Function<String, String[]> wrappingFunction;
 	private boolean isHeaderCell = false;
 
 	// default padding
@@ -32,6 +33,9 @@ public class Cell<T extends PDPage> {
 	private float topPadding = 5f;
 	private float bottomPadding = 5f;
 
+	private static final Function<String, String[]> DEFAULT_WRAP_FUNC
+		= t -> t.split("(?<=\\s|-|@|,|\\.|:|;)");
+
 	private final HorizontalAlignment align;
 	private final VerticalAlignment valign;
 
@@ -39,9 +43,8 @@ public class Cell<T extends PDPage> {
 	float verticalFreeSpace = 0;
 
 	/**
-	 * 
-	 * @param width
-	 *            in % of table width
+	 *
+	 * @param width in % of table width
 	 * @param text
 	 */
 	Cell(Row<T> row, float width, String text, boolean isCalculated, HorizontalAlignment align, VerticalAlignment valign) {
@@ -55,11 +58,12 @@ public class Cell<T extends PDPage> {
 
 		if (getWidth() > row.getWidth()) {
 			throw new IllegalArgumentException(
-					"Cell Width=" + getWidth() + " can't be bigger than row width=" + row.getWidth());
+				"Cell Width=" + getWidth() + " can't be bigger than row width=" + row.getWidth());
 		}
 		this.text = text == null ? "" : text;
 		this.align = align;
 		this.valign = valign;
+		this.wrappingFunction = null;
 	}
 
 	public Color getTextColor() {
@@ -118,7 +122,7 @@ public class Cell<T extends PDPage> {
 	}
 
 	public Paragraph getParagraph() {
-		return new Paragraph(text, font, fontSize, getInnerWidth(), align);
+		return new Paragraph(text, font, fontSize, getInnerWidth(), align, getWrappingFunction());
 	}
 
 	public float getExtraWidth() {
@@ -185,7 +189,7 @@ public class Cell<T extends PDPage> {
 	public PDFont getFontBold() {
 		return fontBold;
 	}
-	
+
 	public void setFontBold(PDFont fontBold) {
 		this.fontBold = fontBold;
 	}
@@ -204,5 +208,17 @@ public class Cell<T extends PDPage> {
 
 	public void setHeaderCell(boolean isHeaderCell) {
 		this.isHeaderCell = isHeaderCell;
+	}
+
+	public Function<String, String[]> getWrappingFunction() {
+		if (null == wrappingFunction) {
+			wrappingFunction = DEFAULT_WRAP_FUNC;
+		}
+
+		return wrappingFunction;
+	}
+
+	public void setWrappingFunction(Function<String, String[]> wrappingFunction) {
+		this.wrappingFunction = wrappingFunction;
 	}
 }

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -43,7 +44,7 @@ public abstract class Table<T extends PDPage> {
 	private final boolean drawLines;
 	private final boolean drawContent;
 	private float headerBottomMargin = 4f;
-	
+
 	private boolean drawDebug;
 
 	public Table(float yStart, float yStartNewPage, float bottomMargin, float width, float margin, PDDocument document,
@@ -90,6 +91,10 @@ public abstract class Table<T extends PDPage> {
 	}
 
 	public void drawTitle(String title, PDFont font, int fontSize, float tableWidth, float height, String alignment) throws IOException {
+		drawTitle(title, font, fontSize, tableWidth, height, alignment, null);
+	}
+
+	public void drawTitle(String title, PDFont font, int fontSize, float tableWidth, float height, String alignment, Function<String, String[]> wrappingFunction) throws IOException {
 
 		if(title == null){
 			// if you don't have title just use height from sublock with max textBox
@@ -97,13 +102,13 @@ public abstract class Table<T extends PDPage> {
 		} else {
 			PDPageContentStream articleTitle = createPdPageContentStream();
 			// TODO: why do we need to cast to int?
-			Paragraph paragraph = new Paragraph(title, font, fontSize, tableWidth, HorizontalAlignment.get(alignment));
+			Paragraph paragraph = new Paragraph(title, font, fontSize, tableWidth, HorizontalAlignment.get(alignment), wrappingFunction);
 			paragraph.setDrawDebug(drawDebug);
 			yStart = paragraph.write(articleTitle, margin, yStart);
 			if(paragraph.getHeight() < height){
 				yStart -= (height -paragraph.getHeight());
 			}
-			
+
 			articleTitle.close();
 		}
 


### PR DESCRIPTION
I needed to customize cell wrapping, so I added support for it. You can now set a function on a Cell instance that tells its Paragraph instance how to divide the string into separate chunks that the table can wrap on. Tested working.

I also added the maven compiler plugin into `pom.xml`, because the project needs it to compile in Netbeans.
